### PR TITLE
Fix tests

### DIFF
--- a/jest-preprocess.js
+++ b/jest-preprocess.js
@@ -2,4 +2,4 @@ const babelOptions = {
   presets: ['babel-preset-gatsby'],
 }
 
-module.exports = require('babel-jest').createTransformer(babelOptions)
+module.exports = require('babel-jest').default.createTransformer(babelOptions)

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,4 +19,5 @@ module.exports = {
   testURL: `http://localhost`,
   setupFiles: [`<rootDir>/loadershim.js`],
   setupFilesAfterEnv: ['<rootDir>/setup-test-env.js'],
+  testEnvironment: 'jsdom',
 }

--- a/src/components/Layout/Header/Nav.test.js
+++ b/src/components/Layout/Header/Nav.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import Nav from './Nav'
 
 describe('Nav', () => {


### PR DESCRIPTION
The following TypeError caused by the previous pull request:

```
TypeError: require(...).createTransformer is not a function
    at Object.<anonymous> (/Users/nicotsou/Developer/nicotsou.com/jest-preprocess.js:5:40)
    at Module._compile (node:internal/modules/cjs/loader:1108:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1137:10)
    at Module.load (node:internal/modules/cjs/loader:973:32)
    at Function.Module._load (node:internal/modules/cjs/loader:813:14)
    at Module.require (node:internal/modules/cjs/loader:997:19)
    at require (node:internal/modules/cjs/helpers:92:18)
    at requireOrImportModule (/Users/nicotsou/Developer/nicotsou.com/node_modules/jest-util/build/requireOrImportModule.js:53:28)
    at /Users/nicotsou/Developer/nicotsou.com/node_modules/@jest/transform/build/ScriptTransformer.js:381:73
    at Array.map (<anonymous>)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

babel-jest@27 switched to ESM, so require is now getting the whole exported scope rather than just the default.